### PR TITLE
Fix: Parcel Invalid Version: undefined issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
     "jest": "^24.9.0",
-    "parcel": "^1.12.3"
+    "parcel": "1.12.3"
   }
 }


### PR DESCRIPTION
Currently parcel build is failing locally while running `npm run app`.
Error:
<img width="1087" alt="Screenshot 2023-02-15 at 15 03 53" src="https://user-images.githubusercontent.com/11209820/218989664-69c18405-a861-4553-bf13-0cbad7a37cf9.png">

This pr fixes the same:
Ref: https://github.com/parcel-bundler/parcel/issues/5943#issuecomment-788556193